### PR TITLE
Replaced alias_method_chain with Module#prepend

### DIFF
--- a/lib/devise_castle/mapping.rb
+++ b/lib/devise_castle/mapping.rb
@@ -1,16 +1,13 @@
 module DeviseCastle
   module Mapping
-    def self.included(base)
-      base.alias_method_chain :default_controllers, :castle
-    end
 
     private
-    def default_controllers_with_castle(options)
+    def default_controllers(options)
       options[:controllers] ||= {}
       options[:controllers][:sessions] ||= "devise_castle/sessions"
       options[:controllers][:registrations] ||= "devise_castle/registrations"
       options[:controllers][:passwords] ||= "devise_castle/passwords"
-      default_controllers_without_castle(options)
+      super
     end
   end
 end

--- a/lib/devise_castle/railtie.rb
+++ b/lib/devise_castle/railtie.rb
@@ -5,7 +5,7 @@ module DeviseCastle
     end
 
     config.after_initialize do
-      Devise::Mapping.send :include, DeviseCastle::Mapping
+      Devise::Mapping.send :prepend, DeviseCastle::Mapping
     end
   end
 end


### PR DESCRIPTION
This fixes compatibility with
https://github.com/scambra/devise_invitable and Module#prepend is also
generally more intuitive.

Blog posts:
https://hashrocket.com/blog/posts/module-prepend-a-super-story
http://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain