### PR TITLE
Switch castle-rb dependency to < 3

### DIFF
--- a/devise_castle.gemspec
+++ b/devise_castle.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{app,lib,config}/**/*")
 
   s.add_dependency("devise", ">= 3.0")
-  s.add_dependency("castle-rb", ">= 1.2", "< 2")
+  s.add_dependency("castle-rb", ">= 1.2", "< 3")
 
   s.add_development_dependency('bundler', '~> 1.1')
 

--- a/lib/devise_castle/version.rb
+++ b/lib/devise_castle/version.rb
@@ -1,3 +1,3 @@
 module DeviseCastle
-  VERSION = "1.4.1".freeze
+  VERSION = "1.4.2".freeze
 end


### PR DESCRIPTION
Let devise-castle use castle-rb 2.0 which is rails 5 compatible. There
are no breaking changes for castle-rb 1.2=>2.x

I filed an issue with Devise-castle maintainers, but keep our fork in the meantime